### PR TITLE
Add CustomLLMBackend support

### DIFF
--- a/Analysis/LLM_CustomLLM.R
+++ b/Analysis/LLM_CustomLLM.R
@@ -2,90 +2,95 @@
 {
 # Run the agent, if initialized 
 if(INITIALIZED_CUSTOM_ENV_TAG){
-  # thePrompt <- "What was the *party* of the Governor of Wisconsin in 1854?"
-  
-  # for fast test 
-  #response <- list("message" = "hi",
-                   #"status_code" = 200)
-    
-  # Run the agent and get a response
-  result <- try(search_agent$invoke(
-      # the normal input dict
-      list( messages = list( list(role = "user", 
-                              content = thePrompt)) ),
-      # the config dict expected by MemorySaver
-      config = list(
-        configurable = list(thread_id = "session-001")  # any string we like as ID
-  ) ), TRUE)
-  theResponseText <- try(result$messages[[length(result$messages)]]$text(),TRUE)
-  
-  # remove XML tags 
-  theResponseText <- gsub("<[^>]+>.*?</[^>]+>\\n?", "", theResponseText)
-  
-  if(class(theResponseText) %in% "try-error"){ 
-    response <- try(list("message"=NA, # NA upon failure 
-                         "status_code"=100), TRUE) 
+  if(CustomLLMBackend == "groq"){
+    result <- try(search_agent$invoke(
+        list(messages = list(list(role = "user", content = thePrompt))),
+        config = list(configurable = list(thread_id = "session-001")), TRUE))
+    theResponseText <- try(result$messages[[length(result$messages)]]$text(), TRUE)
+
+    theResponseText <- gsub("<[^>]+>.*?</[^>]+>\\n?", "", theResponseText)
+
+    if(class(theResponseText) %in% "try-error"){
+      response <- try(list("message" = NA, "status_code" = 100), TRUE)
+    }
+    if(!class(theResponseText) %in% "try-error"){
+      response <- try(list("message" = theResponseText, "status_code" = 200), TRUE)
+    }
   }
-  if(!class(theResponseText) %in% "try-error"){ 
-    response <- try(list("message"=theResponseText, # Last AI Message,
-                         "status_code"=200), TRUE) 
+  if(CustomLLMBackend == "exo"){
+    payload <- list(
+      model = modelName,
+      messages = list(
+        list(role = "system", content = "You are Exo."),
+        list(role = "user",   content = thePrompt)
+      ),
+      temperature = 0.7
+    )
+    resp <- requests$post(exo_url, json = payload, headers = exo_headers)
+    resp$raise_for_status()
+    result <- resp$json()
+    theResponseText <- result$choices[[1]]$message$content
+
+    if(is.null(theResponseText)){
+      response <- try(list("message" = NA, "status_code" = 100), TRUE)
+    } else {
+      response <- try(list("message" = theResponseText, "status_code" = 200), TRUE)
+    }
   }
 }
   
 # Initialize the agent 
-if(!INITIALIZED_CUSTOM_ENV_TAG){ 
+if(!INITIALIZED_CUSTOM_ENV_TAG){
     INITIALIZED_CUSTOM_ENV_TAG <- TRUE
     library(reticulate)
-    
+
     # conda create -n CustomLLMSearch python=3.9
     # conda activate CustomLLMSearch
     # uv pip install streamlit langchain_groq langchain_community python-dotenv arxiv wikipedia duckduckgo-search
-    
-    # Point to your Python environment
+
     use_condaenv("CustomLLMSearch", required = TRUE)
-    
-    # Import Python libraries
-    chatg <- import("langchain_groq")
-    community_utils <- import("langchain_community.utilities")
-    community_tools <- import("langchain_community.tools")
-    agents <- import("langgraph.prebuilt")   
-    MemorySaver <- import("langgraph.checkpoint.memory")$MemorySaver  
-    callbacks <- import("langchain.callbacks")
-    dotenv <- import("dotenv")
-    os <- import("os")
-    
-    # 3. Load .env variables
-    dotenv$load_dotenv()
-    
-    # 4. Create the wrappers/tools
-    arxiv <- community_tools$ArxivQueryRun(api_wrapper = community_utils$ArxivAPIWrapper(
-                                                            top_k_results = 3L,
-                                                            doc_content_char_max = 500L
-                                                          ))
-    wiki <- community_tools$WikipediaQueryRun(api_wrapper = community_utils$WikipediaAPIWrapper(
-                                                      top_k_results = 3L,
-                                                      doc_content_char_max = 500L
-                                                    ))
-    search <- community_tools$DuckDuckGoSearchRun(name = "Search")
-    
-    # define tools for agent 
-    theTools <- list(arxiv, 
-                     wiki, 
-                     search)
-  
-    # Create the LLM
-    theLLM <- chatg$ChatGroq(
-      groq_api_key = os$getenv("GROQ_API_KEY"),
-      model = modelName,
-      temperature = 0.1,
-      streaming = TRUE
-    )
-    
-    # Initialize the agent
-    search_agent <- agents$create_react_agent(  
-      model       = theLLM,
-      tools       = theTools,
-      checkpointer = MemorySaver() # keeps dialogue state
-    )
+
+    if(CustomLLMBackend == "groq"){
+      chatg <- import("langchain_groq")
+      community_utils <- import("langchain_community.utilities")
+      community_tools <- import("langchain_community.tools")
+      agents <- import("langgraph.prebuilt")
+      MemorySaver <- import("langgraph.checkpoint.memory")$MemorySaver
+      callbacks <- import("langchain.callbacks")
+      dotenv <- import("dotenv")
+      os <- import("os")
+      dotenv$load_dotenv()
+
+      arxiv <- community_tools$ArxivQueryRun(api_wrapper = community_utils$ArxivAPIWrapper(
+                                                              top_k_results = 3L,
+                                                              doc_content_char_max = 500L
+                                                            ))
+      wiki <- community_tools$WikipediaQueryRun(api_wrapper = community_utils$WikipediaAPIWrapper(
+                                                        top_k_results = 3L,
+                                                        doc_content_char_max = 500L
+                                                      ))
+      search <- community_tools$DuckDuckGoSearchRun(name = "Search")
+
+      theTools <- list(arxiv, wiki, search)
+
+      theLLM <- chatg$ChatGroq(
+        groq_api_key = os$getenv("GROQ_API_KEY"),
+        model = modelName,
+        temperature = 0.1,
+        streaming = TRUE
+      )
+
+      search_agent <- agents$create_react_agent(
+        model       = theLLM,
+        tools       = theTools,
+        checkpointer = MemorySaver()
+      )
+    }
+
+    if(CustomLLMBackend == "exo"){
+      requests <- import("requests")
+      exo_url <- "http://localhost:52415/v1/chat/completions"
+      exo_headers <- dict("Content-Type" = "application/json")
+    }
   }
 }

--- a/Analysis/LLM_GetPredictions.R
+++ b/Analysis/LLM_GetPredictions.R
@@ -11,7 +11,7 @@
   analysis_var <- "pol_party"            # column name of target covariate
   promptType   <- "BaseSearch"
 
-  LLMProvider <- "CustomLLM"; modelName <- "llama-3.1-8b-instant"; INITIALIZED_CUSTOM_ENV_TAG <- FALSE
+  LLMProvider <- "CustomLLM"; CustomLLMBackend <- "groq"; modelName <- "llama-3.1-8b-instant"; INITIALIZED_CUSTOM_ENV_TAG <- FALSE
   #LLMProvider <- "CustomLLM"; modelName <- "qwen-qwq-32b"; INITIALIZED_CUSTOM_ENV_TAG <- FALSE
   #LLMProvider <- "CustomLLM"; modelName <- "meta-llama/llama-4-scout-17b-16e-instruct"; INITIALIZED_CUSTOM_ENV_TAG <- FALSE
   #LLMProvider <- "CustomLLM"; modelName <- "gemma2-9b-it"; INITIALIZED_CUSTOM_ENV_TAG <- FALSE
@@ -380,6 +380,7 @@
 
     # Write final results to disk
     df$LLMProvider <- LLMProvider
+    df$CustomLLMBackend <- ifelse(LLMProvider == "CustomLLM", CustomLLMBackend, NA)
     df$modelName <- modelName
     df$promptType <- promptType
     df$runTest <- runTest

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ elites and then evaluates the results.
 ## Repository layout
 
 - `Analysis/LLM_GetPredictions.R` – fetches predictions from a selected LLM
-  (OpenAI, DeepSeek or a custom Groq agent).
+  (OpenAI, DeepSeek or a custom agent using Groq or Exo backends).
 - `Analysis/LLM_AnalyzePredictions.R` – combines per‑country results and
   computes accuracy statistics.
 - `Analysis/LLM_DataLocs.R` – small helper file that points to the expected
@@ -27,7 +27,7 @@ in git.
    etc.).
 2. The Python environment `CustomLLMSearch` is expected when using the custom
    search agent.  Required libraries can be installed with `pip` as noted inside
-   `LLM_CustomLLM.R`.
+ `LLM_CustomLLM.R`.
 3. Create a `.env` file in the repository root with any API keys you plan to
    use.  For example:
 
@@ -36,6 +36,8 @@ in git.
    OPENAI_API_KEY=...
    DEEPSEEK_API_KEY=...
    ```
+4. When using the custom agent, set `CustomLLMBackend` in
+   `LLM_GetPredictions.R` to either `"groq"` or `"exo"`.
 
 ## Running the pipeline
 


### PR DESCRIPTION
## Summary
- add `CustomLLMBackend` option in `LLM_GetPredictions.R`
- keep backend info in output dataframe
- document Groq/Exo backend selection in README
- support `groq` and `exo` backends in `LLM_CustomLLM.R`

## Testing
- `python3 --version`
- `Rscript` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849814689e4832f9b12a97610abc463